### PR TITLE
Fix v1 firmware failing to download WireGuard package

### DIFF
--- a/wizard-run
+++ b/wizard-run
@@ -166,7 +166,7 @@ installwireguard () {
         echo "$(date +%Y-%m-%d/%H:%M:%S.%N) [installer] WireGuard deb-file not found, need to download from latest release ..."
         if [ "$onlinecheck" == "true" ]; then
             curl -sLo /tmp/wgpkglatest ${wgpkgapi}
-            pkgurl=$(jq -r '.assets[].browser_download_url | select(test("'$pkgvariant'"))' /tmp/wgpkglatest)
+            pkgurl=$(jq -r '.assets[].browser_download_url | select(contains("'$pkgvariant'"))' /tmp/wgpkglatest)
             echo "$(date +%Y-%m-%d/%H:%M:%S.%N) [installer] Download of WireGuard starting from $pkgurl ..."
             curl -sLO $pkgurl
             echo "$(date +%Y-%m-%d/%H:%M:%S.%N) [installer] download done."


### PR DESCRIPTION
The v1 series of firmware uses an older version of jq that does not support [`test`](https://jqlang.github.io/jq/manual/#test).  Older and newer versions of jq support [`contains`](https://jqlang.github.io/jq/manual/#contains) which functions the same in regard to how it is being used here.  This should address issue #15.